### PR TITLE
Phase 2 (v0.4.0): decouple UI from services

### DIFF
--- a/src/app_context.py
+++ b/src/app_context.py
@@ -1,0 +1,94 @@
+"""
+Application composition root.
+
+All service construction lives here, not inside widgets. MainWindow (and any
+future frontend) receives a fully-built AppContext and only wires callbacks —
+which is what makes the GUI layer swappable.
+"""
+
+import logging
+from dataclasses import dataclass
+from typing import Optional
+
+from models.database import Database
+from services.anime_service import AnimeService
+from utils.config import Config
+from utils.persistence import PersistenceManager
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class AppContext:
+    """The application's non-UI collaborators, fully constructed."""
+
+    config: Config
+    db: Database
+    anime_service: AnimeService
+    persistence: PersistenceManager
+    mal_service: "object"
+    image_service: "object"
+    mal_auth_manager: "object"
+    scrobbling_manager: Optional["object"]
+    mal_api_v2_service: Optional["object"]
+    sync_service: "object"
+
+    @classmethod
+    def build(cls, config: Config, db: Database) -> "AppContext":
+        """Construct all services.
+
+        Must be called after tk.Tk() exists: MALAuthManager may prompt for a
+        client ID with a Tk dialog when no mal_config.json is present.
+        """
+        anime_service = AnimeService(db)
+        persistence = PersistenceManager(config, db)
+
+        from services.image_service import ImageService
+        from services.mal_service import MALService
+
+        mal_service = MALService(config.get_data_directory() / "mal_cache")
+        image_service = ImageService(config.get_data_directory() / "image_cache")
+
+        # Client ID is embedded in the application / read from mal_config.json
+        from ui.mal_auth_dialog import MALAuthManager
+
+        mal_auth_manager = MALAuthManager(config.get_data_directory())
+
+        # WIP scrobbling feature — off by default, absent unless its optional
+        # dependencies are installed
+        scrobbling_manager = None
+        try:
+            from services.scrobbling_manager import ScrobblingManager
+
+            scrobbling_manager = ScrobblingManager(anime_service, config)
+            scrobbling_manager.start()  # No-op unless enabled in settings
+        except Exception as e:
+            logger.warning(f"Failed to initialize ScrobblingManager: {e}")
+
+        # MAL API v2 service only if already authenticated (silent check)
+        mal_api_v2_service = None
+        if mal_auth_manager.is_authenticated(silent=True):
+            from services.mal_api_v2_service import MALAPIv2Service
+
+            mal_api_v2_service = MALAPIv2Service(mal_auth_manager.oauth_client)
+
+        from services.sync_service import SyncService
+
+        sync_service = SyncService(
+            db,
+            mal_api_v2_service,
+            getattr(mal_auth_manager, "oauth_client", None),
+        )
+
+        return cls(
+            config=config,
+            db=db,
+            anime_service=anime_service,
+            persistence=persistence,
+            mal_service=mal_service,
+            image_service=image_service,
+            mal_auth_manager=mal_auth_manager,
+            scrobbling_manager=scrobbling_manager,
+            mal_api_v2_service=mal_api_v2_service,
+            sync_service=sync_service,
+        )

--- a/src/main.py
+++ b/src/main.py
@@ -13,6 +13,7 @@ sys.path.insert(0, str(Path(__file__).parent))
 
 import tkinter as tk
 
+from app_context import AppContext
 from models.database import Database
 from ui.first_run_dialog import FirstRunDialog
 from ui.main_window import MainWindow
@@ -107,7 +108,10 @@ def main():
         root.update_idletasks()
         force_windows_icon()
 
-        app = MainWindow(root, db)
+        # Build all services (composition root); must run after tk.Tk()
+        context = AppContext.build(config, db)
+
+        app = MainWindow(root, context)
 
         # Center window on screen
         root.update_idletasks()

--- a/src/models/database.py
+++ b/src/models/database.py
@@ -2,6 +2,7 @@
 
 import logging
 import sqlite3
+import threading
 from contextlib import contextmanager
 from pathlib import Path
 from typing import List, Optional, Tuple
@@ -10,42 +11,60 @@ logger = logging.getLogger(__name__)
 
 
 class Database:
-    """Manages SQLite database connection and operations"""
+    """Manages SQLite database access with one connection per thread.
+
+    sqlite3 connections cannot be shared across threads. Each thread that
+    touches this Database transparently gets its own connection, so services
+    can be called from worker threads without per-call-site workarounds.
+    """
 
     SCHEMA_VERSION = 2
 
     def __init__(self, db_path: Path):
-        """Initialize database connection
+        """Initialize database
 
         Args:
             db_path: Path to the SQLite database file
         """
         self.db_path = db_path
-        self.connection: Optional[sqlite3.Connection] = None
+        self._local = threading.local()
+
+    @property
+    def connection(self) -> Optional[sqlite3.Connection]:
+        """The current thread's connection, or None if not connected"""
+        return getattr(self._local, "connection", None)
 
     def connect(self):
-        """Establish database connection"""
+        """Establish a database connection for the current thread"""
         try:
-            self.connection = sqlite3.connect(
+            connection = sqlite3.connect(
                 str(self.db_path), detect_types=sqlite3.PARSE_DECLTYPES | sqlite3.PARSE_COLNAMES
             )
-            self.connection.row_factory = sqlite3.Row
-            self.connection.execute("PRAGMA foreign_keys = ON")
-            logger.info(f"Connected to database: {self.db_path}")
+            connection.row_factory = sqlite3.Row
+            connection.execute("PRAGMA foreign_keys = ON")
+            self._local.connection = connection
+            logger.info(
+                f"Connected to database: {self.db_path} "
+                f"(thread {threading.current_thread().name})"
+            )
         except sqlite3.Error as e:
             logger.error(f"Failed to connect to database: {e}")
             raise
 
     def disconnect(self):
-        """Close database connection"""
+        """Close the current thread's database connection.
+
+        Connections belonging to other threads close when their thread's
+        Database usage is released (sqlite3 forbids cross-thread close).
+        """
         if self.connection:
             self.connection.close()
-            self.connection = None
+            self._local.connection = None
             logger.info("Disconnected from database")
 
     @contextmanager
     def get_cursor(self):
-        """Context manager for database cursor
+        """Context manager for a cursor on the current thread's connection
 
         Yields:
             sqlite3.Cursor: Database cursor
@@ -53,12 +72,13 @@ class Database:
         if not self.connection:
             self.connect()
 
-        cursor = self.connection.cursor()
+        connection = self.connection
+        cursor = connection.cursor()
         try:
             yield cursor
-            self.connection.commit()
+            connection.commit()
         except sqlite3.Error as e:
-            self.connection.rollback()
+            connection.rollback()
             logger.error(f"Database error: {e}")
             raise
         finally:
@@ -289,37 +309,6 @@ class Database:
             )
 
             logger.info("Schema migration to v2 completed")
-
-    def execute(self, query: str, params: Optional[Tuple] = None) -> sqlite3.Cursor:
-        """Execute a query
-
-        Args:
-            query: SQL query to execute
-            params: Query parameters
-
-        Returns:
-            sqlite3.Cursor: Query cursor
-        """
-        with self.get_cursor() as cursor:
-            if params:
-                cursor.execute(query, params)
-            else:
-                cursor.execute(query)
-            return cursor
-
-    def executemany(self, query: str, params: List[Tuple]) -> sqlite3.Cursor:
-        """Execute a query with multiple parameter sets
-
-        Args:
-            query: SQL query to execute
-            params: List of parameter tuples
-
-        Returns:
-            sqlite3.Cursor: Query cursor
-        """
-        with self.get_cursor() as cursor:
-            cursor.executemany(query, params)
-            return cursor
 
     def fetchone(self, query: str, params: Optional[Tuple] = None) -> Optional[sqlite3.Row]:
         """Fetch one result

--- a/src/services/sync_controller.py
+++ b/src/services/sync_controller.py
@@ -1,0 +1,97 @@
+"""
+Sync orchestration, extracted from the main window.
+
+The controller owns what happens during a sync (ordering, aggregation,
+outcome shaping); the UI owns only how outcomes are displayed. Callbacks
+fire on the Tk main thread via the run_async worker policy.
+"""
+
+import logging
+from dataclasses import dataclass, field
+from typing import Callable, List, Optional
+
+from utils.worker import run_async
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class SyncOutcome:
+    """Result of a sync run, ready for display."""
+
+    message: str
+    level: str  # "success" | "warning"
+    errors: List[str] = field(default_factory=list)
+    list_changed: bool = False
+
+
+class SyncController:
+    """Runs MAL sync operations on a worker thread and reports outcomes."""
+
+    def __init__(self, root, sync_service):
+        self.root = root
+        self.sync_service = sync_service
+
+    def run(
+        self,
+        sync_type: str,
+        on_complete: Callable[[SyncOutcome], None],
+        on_error: Optional[Callable[[Exception], None]] = None,
+    ):
+        """Run a sync in the background.
+
+        Args:
+            sync_type: "push", "pull", or "full"
+            on_complete: Called on the main thread with a SyncOutcome
+            on_error: Called on the main thread if the sync itself raises
+        """
+        run_async(
+            self.root,
+            lambda: self._run(sync_type),
+            on_done=on_complete,
+            on_error=on_error,
+            name=f"mal-sync-{sync_type}",
+        )
+
+    def _run(self, sync_type: str) -> SyncOutcome:
+        """Perform the sync (worker thread; no UI access)"""
+        service = self.sync_service
+        service.refresh_authentication()
+
+        errors: List[str] = []
+
+        if sync_type == "push":
+            success, failed, push_errors = service.process_sync_queue()
+            errors.extend(push_errors)
+            return SyncOutcome(
+                message=f"Push complete: {success} succeeded, {failed} failed",
+                level="success" if failed == 0 else "warning",
+                errors=errors,
+            )
+
+        if sync_type == "pull":
+            added, updated, pull_errors = service.full_sync_from_mal()
+            errors.extend(pull_errors)
+            return SyncOutcome(
+                message=f"Pull complete: {added} added, {updated} updated",
+                level="success",
+                errors=errors,
+                list_changed=True,
+            )
+
+        if sync_type == "full":
+            push_success, push_failed, push_errors = service.process_sync_queue()
+            added, updated, pull_errors = service.full_sync_from_mal()
+            errors.extend(push_errors)
+            errors.extend(pull_errors)
+            return SyncOutcome(
+                message=(
+                    f"Full sync complete: {push_success} pushed, "
+                    f"{added} added, {updated} updated"
+                ),
+                level="success",
+                errors=errors,
+                list_changed=True,
+            )
+
+        raise ValueError(f"Unknown sync type: {sync_type}")

--- a/src/ui/main_window.py
+++ b/src/ui/main_window.py
@@ -54,6 +54,12 @@ class MainWindow:
         self.mal_api_v2_service = context.mal_api_v2_service
         self.sync_service = context.sync_service
 
+        # Sync orchestration lives in the controller; this window only
+        # displays outcomes
+        from services.sync_controller import SyncController
+
+        self.sync_controller = SyncController(root, context.sync_service)
+
         # Set up notification system
         self.notifications = NotificationManager(root)
         self.error_handler = ErrorHandler(self.notifications)
@@ -1103,97 +1109,31 @@ Added This Week: {stats.get('added_this_week', 0)}"""
             sync_type = dialog.result.get("type")
             self.notifications.show(f"Starting {sync_type} sync...", level="info")
 
-            # Perform sync in background
-            import threading
-
-            thread = threading.Thread(target=self._perform_sync, args=(sync_type,))
-            thread.daemon = True
-            thread.start()
-
-    def _perform_sync(self, sync_type: str):
-        """Perform sync operation in background
-
-        Args:
-            sync_type: Type of sync (push, pull, full)
-        """
-        try:
-            # Database hands out per-thread connections, so the shared sync
-            # service is safe to use from this worker thread directly
-            thread_sync = self.sync_service
-            thread_sync.refresh_authentication()
-
-            all_errors = []
-
-            if sync_type == "push":
-                # Push local changes to MAL
-                success, failed, errors = thread_sync.process_sync_queue()
-
-                self.root.after(
-                    0,
-                    lambda: self.notifications.show(
-                        f"Push complete: {success} succeeded, {failed} failed",
-                        level="success" if failed == 0 else "warning",
-                    ),
-                )
-                all_errors.extend(errors)
-
-            elif sync_type == "pull":
-                # Pull from MAL
-                added, updated, errors = thread_sync.full_sync_from_mal()
-
-                self.root.after(
-                    0,
-                    lambda: self.notifications.show(
-                        f"Pull complete: {added} added, {updated} updated", level="success"
-                    ),
-                )
-                all_errors.extend(errors)
-
-                # Refresh list
-                self.root.after(0, self.refresh_list)
-
-            elif sync_type == "full":
-                # Full bidirectional sync
-                # First push local changes
-                push_success, push_failed, push_errors = thread_sync.process_sync_queue()
-
-                # Then pull from MAL
-                added, updated, pull_errors = thread_sync.full_sync_from_mal()
-
-                self.root.after(
-                    0,
-                    lambda: self.notifications.show(
-                        f"Full sync complete: {push_success} pushed, {added} added, {updated} updated",
-                        level="success",
-                    ),
-                )
-
-                all_errors.extend(push_errors)
-                all_errors.extend(pull_errors)
-
-                # Refresh list
-                self.root.after(0, self.refresh_list)
-
-            # Show errors if any
-            if all_errors:
-                error_msg = "\n".join(all_errors[:5])  # Show first 5 errors
-                if len(all_errors) > 5:
-                    error_msg += f"\n... and {len(all_errors) - 5} more"
-
-                self.root.after(
-                    0,
-                    lambda: messagebox.showwarning(
-                        "Sync Warnings", f"Some items could not be synced:\n\n{error_msg}"
-                    ),
-                )
-
-        except Exception as e:
-            logger.error(f"Sync failed: {e}")
-            error_msg = str(e)
-            self.root.after(
-                0,
-                lambda: messagebox.showerror("Sync Failed", f"Sync operation failed:\n{error_msg}"),
+            self.sync_controller.run(
+                sync_type,
+                on_complete=self._on_sync_complete,
+                on_error=self._on_sync_error,
             )
+
+    def _on_sync_complete(self, outcome):
+        """Display a finished sync's outcome (main thread)"""
+        self.notifications.show(outcome.message, level=outcome.level)
+
+        if outcome.list_changed:
+            self.refresh_list()
+
+        if outcome.errors:
+            error_msg = "\n".join(outcome.errors[:5])  # Show first 5 errors
+            if len(outcome.errors) > 5:
+                error_msg += f"\n... and {len(outcome.errors) - 5} more"
+            messagebox.showwarning(
+                "Sync Warnings", f"Some items could not be synced:\n\n{error_msg}"
+            )
+
+    def _on_sync_error(self, error: Exception):
+        """Display a failed sync (main thread)"""
+        logger.error(f"Sync failed: {error}")
+        messagebox.showerror("Sync Failed", f"Sync operation failed:\n{error!s}")
 
     def show_settings(self):
         """Show settings dialog"""

--- a/src/ui/main_window.py
+++ b/src/ui/main_window.py
@@ -11,6 +11,7 @@ sys.path.insert(0, str(Path(__file__).parent.parent))
 
 from models.anime import Anime
 from ui.dialogs import AddAnimeDialog, EditAnimeDialog
+from ui.theme import apply_theme
 from utils.database_watcher import SmartDatabaseWatcher
 from utils.worker import run_async
 from utils.notifications import (
@@ -98,68 +99,8 @@ class MainWindow:
         self.current_filter = tk.StringVar(value=window_state["filter"])
         self.search_var = tk.StringVar()
 
-        # Configure styles with Mirenku colors and fonts
-        style = ttk.Style()
-
-        # Define Mirenku color palette
-        MIRENKU_TEAL = "#2dd4bf"
-        MIRENKU_TEAL_LIGHT = "#e6fffa"
-        MIRENKU_TEAL_DARK = "#0d9488"
-
-        # Define Mirenku fonts - clean, straightforward, no gimmicks
-        import platform
-
-        system = platform.system()
-
-        if system == "Windows":
-            # Windows: Use Segoe UI for UI, Consolas for data
-            UI_FONT = ("Segoe UI", 9)
-            UI_FONT_BOLD = ("Segoe UI", 9, "bold")
-            DATA_FONT = ("Consolas", 9)
-            HEADING_FONT = ("Segoe UI", 10, "bold")
-        elif system == "Darwin":  # macOS
-            UI_FONT = ("SF Pro Text", 9)
-            UI_FONT_BOLD = ("SF Pro Text", 9, "bold")
-            DATA_FONT = ("SF Mono", 9)
-            HEADING_FONT = ("SF Pro Display", 10, "bold")
-        else:  # Linux and others
-            UI_FONT = ("Noto Sans", 9)
-            UI_FONT_BOLD = ("Noto Sans", 9, "bold")
-            DATA_FONT = ("Roboto Mono", 9)
-            HEADING_FONT = ("Noto Sans", 10, "bold")
-
-        # Apply fonts to default widgets
-        self.root.option_add("*Font", UI_FONT)
-        self.root.option_add("*Menu.Font", UI_FONT)
-        self.root.option_add("*Menubutton.Font", UI_FONT)
-
-        # Configure button styles
-        style.configure(
-            "TButton", font=UI_FONT, borderwidth=1, relief="flat", background=MIRENKU_TEAL_LIGHT
-        )
-        style.map("TButton", background=[("active", MIRENKU_TEAL), ("pressed", MIRENKU_TEAL_DARK)])
-
-        # Configure frame styles
-        style.configure("TFrame", background="white")
-        style.configure("TLabelFrame", background="white", font=UI_FONT_BOLD)
-
-        # Configure label styles
-        style.configure("TLabel", background="white", font=UI_FONT)
-        style.configure("Heading.TLabel", font=HEADING_FONT)
-
-        # Configure entry styles
-        style.configure("TEntry", font=UI_FONT)
-
-        # Configure combobox styles
-        style.configure("TCombobox", font=UI_FONT)
-
-        # Store fonts for later use
-        self.fonts = {
-            "ui": UI_FONT,
-            "ui_bold": UI_FONT_BOLD,
-            "data": DATA_FONT,
-            "heading": HEADING_FONT,
-        }
+        # Apply theme (colors, fonts, ttk styles live in ui/theme.py)
+        self.fonts = apply_theme(self.root)
 
         # Setup UI
         self._create_menu()

--- a/src/ui/main_window.py
+++ b/src/ui/main_window.py
@@ -12,6 +12,7 @@ sys.path.insert(0, str(Path(__file__).parent.parent))
 from models.anime import Anime
 from ui.dialogs import AddAnimeDialog, EditAnimeDialog
 from utils.database_watcher import SmartDatabaseWatcher
+from utils.worker import run_async
 from utils.notifications import (
     ErrorHandler,
     NotificationLevel,
@@ -850,73 +851,71 @@ Added This Week: {stats.get('added_this_week', 0)}"""
         # Show progress
         self.notifications.show("Importing from MAL...", level="info")
 
-        # Import in background thread
-        import threading
+        run_async(
+            self.root,
+            lambda: self._fetch_mal_user_list(username),
+            on_done=lambda result: self._on_mal_user_list_fetched(username, result),
+            on_error=lambda e: messagebox.showerror(
+                "Import Failed", f"Failed to import from MAL: {e!s}"
+            ),
+            name="mal-import",
+        )
 
-        thread = threading.Thread(target=self._import_mal_user_thread, args=(username,))
-        thread.daemon = True
-        thread.start()
+    def _fetch_mal_user_list(self, username: str):
+        """Fetch and normalize a MAL user's list (worker thread; no UI)"""
+        anime_list = self.mal_service.get_user_animelist(username)
 
-    def _import_mal_user_thread(self, username: str):
-        """Background thread for importing MAL user list"""
-        try:
-            # Get user's anime list
-            anime_list = self.mal_service.get_user_animelist(username)
+        if not anime_list:
+            return None
 
-            if not anime_list:
-                self.root.after(
-                    0,
-                    lambda: messagebox.showinfo(
-                        "No Anime Found",
-                        f"No anime found for user '{username}'.\nThe list may be private or the username may be incorrect.",
-                    ),
-                )
-                return
+        # Prepare anime data for preview
+        processed_list = []
+        for mal_anime in anime_list:
+            anime_data = mal_anime.get("anime", {})
 
-            # Prepare anime data for preview
-            processed_list = []
-            for mal_anime in anime_list:
-                anime_data = mal_anime.get("anime", {})
+            # Combine data from list and anime info
+            combined = {
+                "mal_id": anime_data.get("mal_id"),
+                "title": anime_data.get("title", "Unknown"),
+                "title_english": anime_data.get("title_english"),
+                "title_japanese": anime_data.get("title_japanese"),
+                "episodes": anime_data.get("episodes"),
+                "num_episodes_watched": mal_anime.get("episodes_watched", 0),
+                "score": mal_anime.get("score"),
+                "watching_status": mal_anime.get("watching_status"),
+                "synopsis": anime_data.get("synopsis"),
+                "images": anime_data.get("images", {}),
+                "genres": anime_data.get("genres", []),
+                "studios": anime_data.get("studios", []),
+            }
 
-                # Combine data from list and anime info
-                combined = {
-                    "mal_id": anime_data.get("mal_id"),
-                    "title": anime_data.get("title", "Unknown"),
-                    "title_english": anime_data.get("title_english"),
-                    "title_japanese": anime_data.get("title_japanese"),
-                    "episodes": anime_data.get("episodes"),
-                    "num_episodes_watched": mal_anime.get("episodes_watched", 0),
-                    "score": mal_anime.get("score"),
-                    "watching_status": mal_anime.get("watching_status"),
-                    "synopsis": anime_data.get("synopsis"),
-                    "images": anime_data.get("images", {}),
-                    "genres": anime_data.get("genres", []),
-                    "studios": anime_data.get("studios", []),
-                }
-
-                # Map MAL status to readable format
-                status_map = {
-                    1: "watching",
-                    2: "completed",
-                    3: "on_hold",
-                    4: "dropped",
-                    6: "plan_to_watch",
-                }
-                combined["watching_status"] = status_map.get(
-                    mal_anime.get("watching_status"), "unknown"
-                )
-
-                processed_list.append(combined)
-
-            # Show preview dialog on main thread
-            self.root.after(0, lambda: self._show_import_preview(processed_list))
-
-        except Exception as e:
-            logger.error(f"Import failed: {e}")
-            self.root.after(
-                0,
-                lambda: messagebox.showerror("Import Failed", f"Failed to import from MAL: {e!s}"),
+            # Map MAL status to readable format
+            status_map = {
+                1: "watching",
+                2: "completed",
+                3: "on_hold",
+                4: "dropped",
+                6: "plan_to_watch",
+            }
+            combined["watching_status"] = status_map.get(
+                mal_anime.get("watching_status"), "unknown"
             )
+
+            processed_list.append(combined)
+
+        return processed_list
+
+    def _on_mal_user_list_fetched(self, username: str, processed_list):
+        """Show import preview or a not-found notice (main thread)"""
+        if processed_list is None:
+            messagebox.showinfo(
+                "No Anime Found",
+                f"No anime found for user '{username}'.\n"
+                "The list may be private or the username may be incorrect.",
+            )
+            return
+
+        self._show_import_preview(processed_list)
 
     def _show_import_preview(self, anime_list):
         """Show import preview dialog"""
@@ -937,24 +936,41 @@ Added This Week: {stats.get('added_this_week', 0)}"""
         messagebox.showinfo("Import Complete", message)
 
     def update_mal_status(self):
-        """Update MAL connection status in UI"""
-        # Check OAuth authentication status
-        if self.mal_auth_manager.is_authenticated():
+        """Update MAL connection status in UI.
+
+        The check runs on a worker thread: is_authenticated() may perform a
+        synchronous network token refresh, which must never block the Tk
+        main thread (it froze the UI on every 30s poll).
+        """
+
+        def check():
+            return (
+                self.mal_auth_manager.is_authenticated(),
+                self.sync_service.get_sync_queue_count(),
+            )
+
+        run_async(
+            self.root,
+            check,
+            on_done=self._apply_mal_status,
+            on_error=lambda e: self.root.after(30000, self.update_mal_status),
+            name="mal-status",
+        )
+
+    def _apply_mal_status(self, status):
+        """Apply polled MAL status to widgets (main thread)"""
+        is_authenticated, queue_count = status
+
+        if is_authenticated:
             self.mal_status_label.config(text="MAL: ✓", foreground="green")
-        else:
-            self.mal_status_label.config(text="MAL: ✗", foreground="red")
-
-        # Update sync queue count
-        queue_count = self.sync_service.get_sync_queue_count()
-        self.sync_queue_label.config(text=f"Queue: {queue_count}")
-
-        # Update sync button state based on authentication
-        if self.mal_auth_manager.is_authenticated():
             self.sync_button.config(state="normal")
             self.sync_status_label.config(text="Ready", foreground="green")
         else:
+            self.mal_status_label.config(text="MAL: ✗", foreground="red")
             self.sync_button.config(state="disabled")
             self.sync_status_label.config(text="Not Connected", foreground="gray")
+
+        self.sync_queue_label.config(text=f"Queue: {queue_count}")
 
         # Schedule next update in 30 seconds
         self.root.after(30000, self.update_mal_status)
@@ -977,40 +993,33 @@ Added This Week: {stats.get('added_this_week', 0)}"""
             # Not connected, start authentication
             self.notifications.show("Opening browser for MAL authentication...", level="info")
 
-            # Start authentication in background thread
-            import threading
-
-            thread = threading.Thread(target=self._perform_mal_auth)
-            thread.daemon = True
-            thread.start()
-
-    def _perform_mal_auth(self):
-        """Perform MAL authentication in background"""
-        try:
-            success = self.mal_auth_manager.oauth_client.authorize()
-
-            if success:
-                # Update UI on main thread
-                self.root.after(0, self._mal_auth_success)
-            else:
-                self.root.after(
-                    0,
-                    lambda: messagebox.showerror(
-                        "Authentication Failed",
-                        "Failed to authenticate with MyAnimeList.\n\n"
-                        "Please make sure:\n"
-                        "1. You're logged in to MyAnimeList\n"
-                        "2. You authorized the application\n"
-                        "3. Port 8888 is not blocked",
-                    ),
-                )
-        except Exception as e:
-            self.root.after(
-                0,
-                lambda msg=str(e): messagebox.showerror(
-                    "Authentication Error", f"An error occurred during authentication:\n{msg}"
-                ),
+            run_async(
+                self.root,
+                self.mal_auth_manager.oauth_client.authorize,
+                on_done=self._on_mal_auth_result,
+                on_error=self._on_mal_auth_error,
+                name="mal-auth",
             )
+
+    def _on_mal_auth_result(self, success: bool):
+        """Handle auth outcome (main thread)"""
+        if success:
+            self._mal_auth_success()
+        else:
+            messagebox.showerror(
+                "Authentication Failed",
+                "Failed to authenticate with MyAnimeList.\n\n"
+                "Please make sure:\n"
+                "1. You're logged in to MyAnimeList\n"
+                "2. You authorized the application\n"
+                "3. Port 8888 is not blocked",
+            )
+
+    def _on_mal_auth_error(self, error: Exception):
+        """Handle auth exception (main thread)"""
+        messagebox.showerror(
+            "Authentication Error", f"An error occurred during authentication:\n{error!s}"
+        )
 
     def _mal_auth_success(self):
         """Handle successful MAL authentication"""

--- a/src/ui/main_window.py
+++ b/src/ui/main_window.py
@@ -10,10 +10,7 @@ from tkinter import Menu, messagebox, ttk
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
 from models.anime import Anime
-from models.database import Database
-from services.anime_service import AnimeService
 from ui.dialogs import AddAnimeDialog, EditAnimeDialog
-from utils.config import Config
 from utils.database_watcher import SmartDatabaseWatcher
 from utils.notifications import (
     ErrorHandler,
@@ -35,66 +32,26 @@ logger = logging.getLogger(__name__)
 class MainWindow:
     """Main application window"""
 
-    def __init__(self, root: tk.Tk, database: Database):
+    def __init__(self, root: tk.Tk, context: "AppContext"):
         """Initialize main window
 
         Args:
             root: Tkinter root window
-            database: Database instance
+            context: Fully-built application context (composition root lives
+                in app_context.py, not here)
         """
         self.root = root
-        self.db = database
-        self.service = AnimeService(database)
-        self.config = Config()
-        self.persistence = PersistenceManager(self.config, database)
-
-        # Set up MAL service
-        from services.mal_service import MALService
-
-        cache_dir = self.config.get_data_directory() / "mal_cache"
-        self.mal_service = MALService(cache_dir)
-
-        # Set up image service
-        from services.image_service import ImageService
-
-        image_cache_dir = self.config.get_data_directory() / "image_cache"
-        self.image_service = ImageService(image_cache_dir)
-
-        # Set up MAL OAuth2 authentication (Phase 3)
-        from ui.mal_auth_dialog import MALAuthManager
-
-        self.mal_auth_manager = MALAuthManager(
-            self.config.get_data_directory()
-            # Client ID is embedded in the application
-        )
-
-        # Set up ScrobblingManager for WebSocket server (v0.4.0)
-        try:
-            from services.scrobbling_manager import ScrobblingManager
-            self.scrobbling_manager = ScrobblingManager(self.service, self.config)
-            # Start server if enabled
-            self.scrobbling_manager.start()
-        except Exception as e:
-            logger.warning(f"Failed to initialize ScrobblingManager: {e}")
-            self.scrobbling_manager = None
-
-        # Set up MAL API v2 service if authenticated (silent check at startup)
-        self.mal_api_v2_service = None
-        if self.mal_auth_manager.is_authenticated(silent=True):
-            from services.mal_api_v2_service import MALAPIv2Service
-
-            self.mal_api_v2_service = MALAPIv2Service(self.mal_auth_manager.oauth_client)
-
-        # Set up sync service (Phase 3 functionality)
-        from services.sync_service import SyncService
-
-        self.sync_service = SyncService(
-            database,
-            self.mal_api_v2_service,
-            self.mal_auth_manager.oauth_client
-            if hasattr(self.mal_auth_manager, "oauth_client")
-            else None,
-        )
+        self.context = context
+        self.db = context.db
+        self.service = context.anime_service
+        self.config = context.config
+        self.persistence = context.persistence
+        self.mal_service = context.mal_service
+        self.image_service = context.image_service
+        self.mal_auth_manager = context.mal_auth_manager
+        self.scrobbling_manager = context.scrobbling_manager
+        self.mal_api_v2_service = context.mal_api_v2_service
+        self.sync_service = context.sync_service
 
         # Set up notification system
         self.notifications = NotificationManager(root)

--- a/src/ui/main_window.py
+++ b/src/ui/main_window.py
@@ -1151,17 +1151,9 @@ Added This Week: {stats.get('added_this_week', 0)}"""
             sync_type: Type of sync (push, pull, full)
         """
         try:
-            # Create new database connection for this thread
-            from models.database import Database
-
-            thread_db = Database(str(self.config.db_path))
-
-            # Create new sync service with thread-safe database
-            from services.sync_service import SyncService
-
-            thread_sync = SyncService(
-                thread_db, self.mal_api_v2_service, self.mal_auth_manager.oauth_client
-            )
+            # Database hands out per-thread connections, so the shared sync
+            # service is safe to use from this worker thread directly
+            thread_sync = self.sync_service
             thread_sync.refresh_authentication()
 
             all_errors = []

--- a/src/ui/theme.py
+++ b/src/ui/theme.py
@@ -1,0 +1,83 @@
+"""
+Mirenku theme: colors, fonts, and ttk style configuration.
+
+One place to change the app's look. Phase 3 (sv-ttk) replaces the body of
+apply_theme() without touching any window code.
+"""
+
+import platform
+from tkinter import ttk
+
+# Mirenku color palette
+MIRENKU_TEAL = "#2dd4bf"
+MIRENKU_TEAL_LIGHT = "#e6fffa"
+MIRENKU_TEAL_DARK = "#0d9488"
+
+
+def get_fonts() -> dict:
+    """Platform-appropriate fonts — clean, straightforward, no gimmicks"""
+    system = platform.system()
+
+    if system == "Windows":
+        # Windows: Segoe UI for UI, Consolas for data
+        return {
+            "ui": ("Segoe UI", 9),
+            "ui_bold": ("Segoe UI", 9, "bold"),
+            "data": ("Consolas", 9),
+            "heading": ("Segoe UI", 10, "bold"),
+        }
+    if system == "Darwin":  # macOS
+        return {
+            "ui": ("SF Pro Text", 9),
+            "ui_bold": ("SF Pro Text", 9, "bold"),
+            "data": ("SF Mono", 9),
+            "heading": ("SF Pro Display", 10, "bold"),
+        }
+    # Linux and others
+    return {
+        "ui": ("Noto Sans", 9),
+        "ui_bold": ("Noto Sans", 9, "bold"),
+        "data": ("Roboto Mono", 9),
+        "heading": ("Noto Sans", 10, "bold"),
+    }
+
+
+def apply_theme(root) -> dict:
+    """Apply the Mirenku theme to a Tk root.
+
+    Returns:
+        The fonts dict for widgets that need explicit fonts.
+    """
+    fonts = get_fonts()
+    style = ttk.Style()
+
+    # Apply fonts to default widgets
+    root.option_add("*Font", fonts["ui"])
+    root.option_add("*Menu.Font", fonts["ui"])
+    root.option_add("*Menubutton.Font", fonts["ui"])
+
+    # Button styles
+    style.configure(
+        "TButton",
+        font=fonts["ui"],
+        borderwidth=1,
+        relief="flat",
+        background=MIRENKU_TEAL_LIGHT,
+    )
+    style.map(
+        "TButton", background=[("active", MIRENKU_TEAL), ("pressed", MIRENKU_TEAL_DARK)]
+    )
+
+    # Frame styles
+    style.configure("TFrame", background="white")
+    style.configure("TLabelFrame", background="white", font=fonts["ui_bold"])
+
+    # Label styles
+    style.configure("TLabel", background="white", font=fonts["ui"])
+    style.configure("Heading.TLabel", font=fonts["heading"])
+
+    # Entry and combobox styles
+    style.configure("TEntry", font=fonts["ui"])
+    style.configure("TCombobox", font=fonts["ui"])
+
+    return fonts

--- a/src/utils/worker.py
+++ b/src/utils/worker.py
@@ -1,0 +1,97 @@
+"""
+One threading policy for UI-triggered background work.
+
+Every background task in the app goes through run_async: work runs on a
+daemon worker thread, results and errors are always marshaled back to the
+Tk main thread. No call site hand-rolls threading again.
+
+Marshaling detail: worker threads NEVER call into Tk. tkinter's after() is
+not reliably thread-safe (it raises "main thread is not in main loop" when
+the main thread is outside mainloop, and can misbehave even inside it).
+Instead, callbacks are posted to a plain thread-safe queue that a pump —
+scheduled on the main thread via after() — drains every 50ms.
+"""
+
+import logging
+import queue
+import threading
+
+logger = logging.getLogger(__name__)
+
+_PUMP_INTERVAL_MS = 50
+_DISPATCHER_ATTR = "_mirenku_worker_dispatcher"
+
+
+class _TkDispatcher:
+    """Delivers callables to the Tk main thread via a polled queue."""
+
+    def __init__(self, root):
+        self._root = root
+        self._queue = queue.SimpleQueue()
+        self._pump()
+
+    def post(self, callback):
+        """Thread-safe: enqueue a callable to run on the main thread"""
+        self._queue.put(callback)
+
+    def _pump(self):
+        """Drain pending callbacks; runs on the main thread only"""
+        while True:
+            try:
+                callback = self._queue.get_nowait()
+            except queue.Empty:
+                break
+            try:
+                callback()
+            except Exception:
+                logger.exception("Marshaled callback failed")
+        try:
+            self._root.after(_PUMP_INTERVAL_MS, self._pump)
+        except Exception:
+            # Root destroyed — stop pumping
+            pass
+
+
+def _get_dispatcher(root) -> _TkDispatcher:
+    dispatcher = getattr(root, _DISPATCHER_ATTR, None)
+    if dispatcher is None:
+        dispatcher = _TkDispatcher(root)
+        setattr(root, _DISPATCHER_ATTR, dispatcher)
+    return dispatcher
+
+
+def run_async(root, fn, on_done=None, on_error=None, name=None):
+    """Run fn() on a worker thread and marshal the outcome to the Tk thread.
+
+    Must be called from the main thread (it starts the marshaling pump on
+    first use). All app call sites are UI event handlers, which satisfies
+    this naturally.
+
+    Args:
+        root: Tk root (owns the event loop used for marshaling)
+        fn: No-arg callable executed on the worker thread
+        on_done: Called on the MAIN thread with fn's return value
+        on_error: Called on the MAIN thread with the exception if fn raises.
+            If omitted, the error is logged and swallowed.
+        name: Thread name for logs/debugging
+
+    Returns:
+        The started thread (daemon).
+    """
+    task_name = name or getattr(fn, "__name__", "task")
+    dispatcher = _get_dispatcher(root)
+
+    def _target():
+        try:
+            result = fn()
+        except Exception as e:
+            logger.error(f"Background task '{task_name}' failed: {e}", exc_info=True)
+            if on_error is not None:
+                dispatcher.post(lambda exc=e: on_error(exc))
+            return
+        if on_done is not None:
+            dispatcher.post(lambda r=result: on_done(r))
+
+    thread = threading.Thread(target=_target, daemon=True, name=f"worker-{task_name}")
+    thread.start()
+    return thread

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -228,3 +228,71 @@ class TestAnimeModel(unittest.TestCase):
 
 if __name__ == '__main__':
     unittest.main()
+
+class TestPerThreadConnections:
+    """Regression (R2a): Database must hand out one connection per thread so
+    services can be shared across threads. The old single shared connection
+    raised sqlite3.ProgrammingError from any worker thread."""
+
+    def test_worker_thread_can_use_same_database(self, tmp_path):
+        import threading
+        from models.database import Database
+
+        db = Database(tmp_path / "anime_tracker.db")
+        db.initialize()
+
+        with db.get_cursor() as cursor:
+            cursor.execute(
+                "INSERT INTO anime (title, status) VALUES (?, ?)",
+                ("Main Thread Anime", "Watching"),
+            )
+
+        results = {}
+
+        def worker():
+            try:
+                row = db.fetchone("SELECT COUNT(*) as c FROM anime")
+                results["count"] = row["c"]
+                with db.get_cursor() as cursor:
+                    cursor.execute(
+                        "INSERT INTO anime (title, status) VALUES (?, ?)",
+                        ("Worker Thread Anime", "Completed"),
+                    )
+                results["ok"] = True
+            except Exception as e:
+                results["error"] = repr(e)
+
+        t = threading.Thread(target=worker)
+        t.start()
+        t.join(timeout=10)
+
+        assert results.get("error") is None
+        assert results.get("ok") is True
+        assert results["count"] == 1
+        # Main thread sees the worker's committed write
+        assert db.fetchone("SELECT COUNT(*) as c FROM anime")["c"] == 2
+
+        db.disconnect()
+
+    def test_connections_are_distinct_per_thread(self, tmp_path):
+        import threading
+        from models.database import Database
+
+        db = Database(tmp_path / "anime_tracker.db")
+        db.initialize()
+        main_conn = db.connection
+
+        seen = {}
+
+        def worker():
+            db.fetchone("SELECT 1")
+            seen["conn"] = db.connection
+
+        t = threading.Thread(target=worker)
+        t.start()
+        t.join(timeout=10)
+
+        assert seen["conn"] is not None
+        assert seen["conn"] is not main_conn
+
+        db.disconnect()

--- a/tests/test_main_window_wiring.py
+++ b/tests/test_main_window_wiring.py
@@ -11,7 +11,38 @@ from unittest.mock import Mock, patch
 # Add src to path for imports
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'src'))
 
+from app_context import AppContext
 from models.database import Database
+from services.anime_service import AnimeService
+from services.sync_service import SyncService
+from utils.persistence import PersistenceManager
+
+
+def make_test_context(tmp_path, db, mal_auth_manager=None):
+    """AppContext with real core services and no MAL/scrobbling machinery —
+    the injectability MainWindow gains from R1"""
+    mock_config = Mock()
+    mock_config.get_db_path.return_value = db.db_path
+    mock_config.get_data_directory.return_value = tmp_path
+    mock_config.get.side_effect = lambda key, default=None: default
+
+    auth = mal_auth_manager or Mock()
+    if mal_auth_manager is None:
+        auth.oauth_client = None
+        auth.is_authenticated.return_value = False
+
+    return AppContext(
+        config=mock_config,
+        db=db,
+        anime_service=AnimeService(db),
+        persistence=PersistenceManager(mock_config, db),
+        mal_service=Mock(),
+        image_service=Mock(),
+        mal_auth_manager=auth,
+        scrobbling_manager=None,
+        mal_api_v2_service=None,
+        sync_service=SyncService(db, None, None),
+    )
 
 
 @pytest.mark.gui
@@ -34,20 +65,12 @@ class TestMainWindowWiring:
         db = Database(db_path)
         db.initialize()
 
-        mock_config = Mock()
-        mock_config.get_db_path.return_value = db_path
-        mock_config.get_data_directory.return_value = tmp_path
-        mock_config.get.side_effect = lambda key, default=None: default
+        context = make_test_context(tmp_path, db)
 
-        mock_auth_manager = Mock()
-        mock_auth_manager.oauth_client = None
-
-        with patch("ui.main_window.Config", return_value=mock_config), \
-             patch("ui.mal_auth_dialog.MALAuthManager", return_value=mock_auth_manager), \
-             patch("ui.main_window.SmartDatabaseWatcher") as mock_watcher:
+        with patch("ui.main_window.SmartDatabaseWatcher") as mock_watcher:
             from ui.main_window import MainWindow
 
-            MainWindow(root, db)
+            MainWindow(root, context)
 
             watched_path = mock_watcher.call_args.kwargs["db_path"]
             assert watched_path == db_path
@@ -55,7 +78,6 @@ class TestMainWindowWiring:
             assert watched_path.exists()
 
         db.disconnect()
-
 
     def test_auth_error_reaches_error_dialog(self, root, tmp_path):
         """Regression (F4): the auth except-branch referenced an unbound
@@ -65,21 +87,15 @@ class TestMainWindowWiring:
         db = Database(db_path)
         db.initialize()
 
-        mock_config = Mock()
-        mock_config.get_db_path.return_value = db_path
-        mock_config.get_data_directory.return_value = tmp_path
-        mock_config.get.side_effect = lambda key, default=None: default
-
         mock_auth_manager = Mock()
         mock_auth_manager.oauth_client.authorize.side_effect = RuntimeError("boom")
 
-        with patch("ui.main_window.Config", return_value=mock_config), \
-             patch("ui.mal_auth_dialog.MALAuthManager", return_value=mock_auth_manager), \
-             patch("ui.main_window.SmartDatabaseWatcher"):
+        context = make_test_context(tmp_path, db, mal_auth_manager=mock_auth_manager)
+
+        with patch("ui.main_window.SmartDatabaseWatcher"):
             from ui.main_window import MainWindow
 
-            window = MainWindow(root, db)
-            window.mal_auth_manager = mock_auth_manager
+            window = MainWindow(root, context)
 
             with patch("tkinter.messagebox.showerror") as mock_error:
                 window._perform_mal_auth()
@@ -87,5 +103,27 @@ class TestMainWindowWiring:
 
                 mock_error.assert_called_once()
                 assert "boom" in mock_error.call_args[0][1]
+
+        db.disconnect()
+
+    def test_main_window_uses_context_services(self, root, tmp_path):
+        """Regression (R1): MainWindow must use the injected collaborators,
+        not construct its own."""
+        db_path = tmp_path / "anime_tracker.db"
+        db = Database(db_path)
+        db.initialize()
+
+        context = make_test_context(tmp_path, db)
+
+        with patch("ui.main_window.SmartDatabaseWatcher"):
+            from ui.main_window import MainWindow
+
+            window = MainWindow(root, context)
+
+            assert window.db is context.db
+            assert window.service is context.anime_service
+            assert window.config is context.config
+            assert window.sync_service is context.sync_service
+            assert window.mal_auth_manager is context.mal_auth_manager
 
         db.disconnect()

--- a/tests/test_main_window_wiring.py
+++ b/tests/test_main_window_wiring.py
@@ -80,14 +80,17 @@ class TestMainWindowWiring:
         db.disconnect()
 
     def test_auth_error_reaches_error_dialog(self, root, tmp_path):
-        """Regression (F4): the auth except-branch referenced an unbound
-        exception variable, so real auth failures raised NameError inside
-        the after-callback instead of showing the error dialog."""
+        """Regression (F4/R2b): a failing MAL authorization must surface the
+        real error in a dialog on the main thread — it used to raise
+        NameError inside the marshaled callback instead."""
+        import time
+
         db_path = tmp_path / "anime_tracker.db"
         db = Database(db_path)
         db.initialize()
 
         mock_auth_manager = Mock()
+        mock_auth_manager.is_authenticated.return_value = False
         mock_auth_manager.oauth_client.authorize.side_effect = RuntimeError("boom")
 
         context = make_test_context(tmp_path, db, mal_auth_manager=mock_auth_manager)
@@ -98,8 +101,13 @@ class TestMainWindowWiring:
             window = MainWindow(root, context)
 
             with patch("tkinter.messagebox.showerror") as mock_error:
-                window._perform_mal_auth()
-                root.update()  # drain the after() queue
+                window.quick_mal_connect()
+
+                # Pump the Tk loop until the worker's error is marshaled back
+                deadline = time.time() + 5
+                while not mock_error.called and time.time() < deadline:
+                    root.update()
+                    time.sleep(0.01)
 
                 mock_error.assert_called_once()
                 assert "boom" in mock_error.call_args[0][1]

--- a/tests/test_sync_controller.py
+++ b/tests/test_sync_controller.py
@@ -1,0 +1,78 @@
+"""
+Test suite for SyncController (R3) — sync orchestration extracted from the
+main window.
+"""
+
+import pytest
+import sys
+import os
+from unittest.mock import Mock
+
+# Add src to path for imports
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'src'))
+
+from services.sync_controller import SyncController, SyncOutcome
+
+
+@pytest.fixture
+def sync_service():
+    service = Mock()
+    service.process_sync_queue.return_value = (3, 0, [])
+    service.full_sync_from_mal.return_value = (2, 5, [])
+    return service
+
+
+@pytest.fixture
+def controller(sync_service):
+    return SyncController(root=Mock(), sync_service=sync_service)
+
+
+class TestSyncOrchestration:
+    def test_push(self, controller, sync_service):
+        outcome = controller._run("push")
+
+        sync_service.refresh_authentication.assert_called_once()
+        sync_service.process_sync_queue.assert_called_once()
+        sync_service.full_sync_from_mal.assert_not_called()
+        assert outcome.message == "Push complete: 3 succeeded, 0 failed"
+        assert outcome.level == "success"
+        assert outcome.list_changed is False
+
+    def test_push_with_failures_is_warning(self, controller, sync_service):
+        sync_service.process_sync_queue.return_value = (1, 2, ["err1", "err2"])
+
+        outcome = controller._run("push")
+
+        assert outcome.level == "warning"
+        assert outcome.errors == ["err1", "err2"]
+
+    def test_pull(self, controller, sync_service):
+        outcome = controller._run("pull")
+
+        sync_service.full_sync_from_mal.assert_called_once()
+        sync_service.process_sync_queue.assert_not_called()
+        assert outcome.message == "Pull complete: 2 added, 5 updated"
+        assert outcome.list_changed is True
+
+    def test_full_pushes_before_pulling(self, controller, sync_service):
+        calls = []
+        sync_service.process_sync_queue.side_effect = lambda: calls.append("push") or (3, 0, [])
+        sync_service.full_sync_from_mal.side_effect = lambda: calls.append("pull") or (2, 5, [])
+
+        outcome = controller._run("full")
+
+        assert calls == ["push", "pull"]
+        assert outcome.message == "Full sync complete: 3 pushed, 2 added, 5 updated"
+        assert outcome.list_changed is True
+
+    def test_full_aggregates_errors_from_both_directions(self, controller, sync_service):
+        sync_service.process_sync_queue.return_value = (1, 1, ["push_err"])
+        sync_service.full_sync_from_mal.return_value = (0, 0, ["pull_err"])
+
+        outcome = controller._run("full")
+
+        assert outcome.errors == ["push_err", "pull_err"]
+
+    def test_unknown_sync_type_raises(self, controller):
+        with pytest.raises(ValueError):
+            controller._run("sideways")

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -1,0 +1,96 @@
+"""
+Test suite for the run_async worker utility (R2b) — the single threading
+policy for UI-triggered background work.
+"""
+
+import pytest
+import sys
+import os
+import threading
+import time
+import tkinter as tk
+
+# Add src to path for imports
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'src'))
+
+from utils.worker import run_async
+
+
+@pytest.fixture(scope="module")
+def root():
+    """One root for the module — rapid Tk() create/destroy cycles are flaky
+    on Windows"""
+    root = tk.Tk()
+    root.withdraw()
+    yield root
+    try:
+        root.destroy()
+    except:
+        pass
+
+
+@pytest.mark.gui
+class TestRunAsync:
+
+    def drain(self, root, condition, timeout=5.0):
+        """Pump the Tk event loop until condition() or timeout"""
+        deadline = time.time() + timeout
+        while not condition() and time.time() < deadline:
+            root.update()
+            time.sleep(0.01)
+
+    def test_result_marshaled_to_main_thread(self, root):
+        seen = {}
+        main_thread = threading.current_thread()
+
+        def work():
+            seen["work_thread"] = threading.current_thread()
+            return 42
+
+        def on_done(result):
+            seen["result"] = result
+            seen["done_thread"] = threading.current_thread()
+
+        run_async(root, work, on_done=on_done)
+        self.drain(root, lambda: "result" in seen)
+
+        assert seen["result"] == 42
+        assert seen["work_thread"] is not main_thread
+        assert seen["done_thread"] is main_thread
+
+    def test_error_marshaled_to_main_thread(self, root):
+        seen = {}
+        main_thread = threading.current_thread()
+
+        def work():
+            raise RuntimeError("boom")
+
+        def on_error(exc):
+            seen["error"] = exc
+            seen["error_thread"] = threading.current_thread()
+
+        run_async(root, work, on_error=on_error)
+        self.drain(root, lambda: "error" in seen)
+
+        assert isinstance(seen["error"], RuntimeError)
+        assert str(seen["error"]) == "boom"
+        assert seen["error_thread"] is main_thread
+
+    def test_error_without_handler_is_swallowed(self, root):
+        thread = run_async(root, lambda: 1 / 0)
+        thread.join(timeout=5)
+        root.update()  # must not raise
+
+    def test_on_done_not_called_on_error(self, root):
+        seen = {"done": False, "error": False}
+
+        run_async(
+            root,
+            lambda: 1 / 0,
+            on_done=lambda r: seen.update(done=True),
+            on_error=lambda e: seen.update(error=True),
+        )
+        self.drain(root, lambda: seen["error"])
+
+        assert seen["error"] is True
+        assert seen["done"] is False


### PR DESCRIPTION
Implements Phase 2 of `docs/REVISION_PLAN.md` — the architectural pass that makes the GUI layer swappable. One commit per item.

## Changes
- **R2a — One database connection per thread.** `Database` hands out per-thread connections via `threading.local`. Removes the crash class where any service call from a worker thread hit `sqlite3.ProgrammingError`, and deletes the workaround that built a fresh `Database`+`SyncService` per sync. Also deletes `Database.execute()/executemany()` (zero callers; `execute()` returned an already-closed cursor).
- **R1 — AppContext composition root.** All ten service constructions move out of `MainWindow.__init__` into `AppContext.build()` in `app_context.py`, called from `main()`. `MainWindow` receives collaborators; tests now inject a plain test context instead of patching constructors.
- **R2b — Single threading policy.** New `utils/worker.py` `run_async()` owns worker-thread creation and main-thread marshaling. Workers never call into Tk — `after()` from a non-main thread is not reliably safe (raises "main thread is not in main loop") — outcomes go through a thread-safe queue drained by a main-thread pump. Converted: MAL auth, MAL user-list import, and the 30-second status poll whose `is_authenticated()` check could do a synchronous network token refresh **on the Tk main thread**, freezing the UI every poll.
- **R3 — SyncController extracted.** Sync orchestration (ordering, aggregation, `SyncOutcome` shaping) moves to `services/sync_controller.py`; the window keeps two display callbacks. Replaces the last hand-rolled thread spawn.
- **R4 — Theme extracted.** Colors/fonts/ttk styles move to `ui/theme.py` with one `apply_theme(root)` entry point — Phase 3 (sv-ttk) swaps its body without touching window code.

`main_window.py`: 1205 → 1077 lines, and it no longer constructs services, spawns threads, owns sync logic, or defines styling. Any future frontend (sv-ttk restyle, pywebview, Qt) reuses AppContext + run_async + SyncController unchanged. The scrobbling redesign spike is now unblocked (it depends on R2a).

## Gate
Full suite: 264 passed, 23 failed — failing set is name-for-name the pre-existing baseline verified against `main` in Phase 0; zero new failures (+12 new tests). App boots and runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
